### PR TITLE
Define VPC and OpenShift operating CIDRs and subnet counts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,9 @@ module "network" {
   source        = "modules/network"
   platform_name = "${var.platform_name}"
   platform_cidr = "${var.platform_cidr}"
+
+  pub_subnet_count  = "${var.pub_subnet_count}"
+  priv_subnet_count = "${var.priv_subnet_count}"
 }
 
 module "infra" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 module "network" {
   source        = "modules/network"
   platform_name = "${var.platform_name}"
+  platform_cidr = "${var.platform_cidr}"
 }
 
 module "infra" {
@@ -60,4 +61,6 @@ module "openshift" {
   google_client_id     = "${var.google_client_id}"
   google_client_secret = "${var.google_client_secret}"
   google_client_domain = "${var.google_client_domain}"
+
+  openshift_cluster_cidr = "${var.openshift_cluster_cidr}"
 }

--- a/main.tf
+++ b/main.tf
@@ -6,10 +6,10 @@ module "network" {
 module "infra" {
   source = "modules/infra"
 
-  platform_name = "${var.platform_name}"
-  use_community = "${var.use_community}"
-  use_specific_base_image = "${var.use_specific_base_image}"
-  specific_base_image_id = "${var.specific_base_image_id}"
+  platform_name                        = "${var.platform_name}"
+  use_community                        = "${var.use_community}"
+  use_specific_base_image              = "${var.use_specific_base_image}"
+  specific_base_image_id               = "${var.specific_base_image_id}"
   specific_base_image_root_device_name = "${var.specific_base_image_root_device_name}"
 
   platform_vpc_id    = "${module.network.platform_vpc_id}"
@@ -55,9 +55,9 @@ module "openshift" {
   public_certificate_key              = "${module.domain.public_certificate_key}"
   public_certificate_intermediate_pem = "${module.domain.public_certificate_intermediate_pem}"
 
-  identity_providers         = "${var.identity_providers}"
+  identity_providers = "${var.identity_providers}"
 
-  google_client_id           = "${var.google_client_id}"
-  google_client_secret       = "${var.google_client_secret}"
-  google_client_domain       = "${var.google_client_domain}"
+  google_client_id     = "${var.google_client_id}"
+  google_client_secret = "${var.google_client_secret}"
+  google_client_domain = "${var.google_client_domain}"
 }

--- a/main.tf
+++ b/main.tf
@@ -65,5 +65,6 @@ module "openshift" {
   google_client_secret = "${var.google_client_secret}"
   google_client_domain = "${var.google_client_domain}"
 
-  openshift_cluster_cidr = "${var.openshift_cluster_cidr}"
+  openshift_cluster_cidr  = "${var.openshift_cluster_cidr}"
+  openshift_services_cidr = "${var.openshift_services_cidr}"
 }

--- a/modules/network/private_network.tf
+++ b/modules/network/private_network.tf
@@ -2,7 +2,7 @@
 
 # For Outbound access
 locals {
-  private_subnet_count = "${length(data.aws_availability_zones.available.names)}"
+  private_subnet_count = "${min(var.priv_subnet_count, length(data.aws_availability_zones.available.names))}"
 }
 
 resource "aws_subnet" "private" {

--- a/modules/network/public_network.tf
+++ b/modules/network/public_network.tf
@@ -1,7 +1,7 @@
 # Public subnet: for router LB
 
 locals {
-  public_subnet_count = "${length(data.aws_availability_zones.available.names)}"
+  public_subnet_count = "${min(var.pub_subnet_count, length(data.aws_availability_zones.available.names))}"
 }
 
 resource "aws_subnet" "public" {

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -3,3 +3,6 @@ variable "platform_name" {}
 variable "platform_cidr" {
   default = "10.0.0.0/16"
 }
+
+variable "pub_subnet_count" {}
+variable "priv_subnet_count" {}

--- a/modules/openshift/inventory.tf
+++ b/modules/openshift/inventory.tf
@@ -20,6 +20,7 @@ data "template_file" "template_inventory" {
     google_client_domain            = "${var.google_client_domain}"
     use_htpasswd_identity_provider  = "${contains(var.identity_providers, "HTPasswdPasswordIdentityProvider")}"
     openshift_cluster_cidr          = "${var.openshift_cluster_cidr}"
+    openshift_services_cidr         = "${var.openshift_services_cidr}"
   }
 }
 

--- a/modules/openshift/inventory.tf
+++ b/modules/openshift/inventory.tf
@@ -19,6 +19,7 @@ data "template_file" "template_inventory" {
     google_client_secret            = "${var.google_client_secret}"
     google_client_domain            = "${var.google_client_domain}"
     use_htpasswd_identity_provider  = "${contains(var.identity_providers, "HTPasswdPasswordIdentityProvider")}"
+    openshift_cluster_cidr          = "${var.openshift_cluster_cidr}"
   }
 }
 

--- a/modules/openshift/resources/template-inventory.yaml
+++ b/modules/openshift/resources/template-inventory.yaml
@@ -37,6 +37,7 @@ ${use_htpasswd_identity_provider == "true" ? "" : "#"}        kind: HTPasswdPass
 ${use_htpasswd_identity_provider == "true" ? "" : "#"}        filename: /etc/origin/master/htpasswd
     os_sdn_network_plugin_name: 'redhat/openshift-ovs-networkpolicy'
     osm_cluster_network_cidr: ${openshift_cluster_cidr}
+    openshift_portal_net: ${openshift_services_cidr}
     openshift_disable_check: 'disk_availability,memory_availability,docker_image_availability'
     openshift_master_cluster_hostname: ${master_domain}
     openshift_master_cluster_public_hostname: ${platform_domain}

--- a/modules/openshift/resources/template-inventory.yaml
+++ b/modules/openshift/resources/template-inventory.yaml
@@ -36,6 +36,7 @@ ${use_htpasswd_identity_provider == "true" ? "" : "#"}        mappingMethod: cla
 ${use_htpasswd_identity_provider == "true" ? "" : "#"}        kind: HTPasswdPasswordIdentityProvider
 ${use_htpasswd_identity_provider == "true" ? "" : "#"}        filename: /etc/origin/master/htpasswd
     os_sdn_network_plugin_name: 'redhat/openshift-ovs-networkpolicy'
+    osm_cluster_network_cidr: ${openshift_cluster_cidr}
     openshift_disable_check: 'disk_availability,memory_availability,docker_image_availability'
     openshift_master_cluster_hostname: ${master_domain}
     openshift_master_cluster_public_hostname: ${platform_domain}

--- a/modules/openshift/variables.tf
+++ b/modules/openshift/variables.tf
@@ -27,6 +27,12 @@ variable "google_client_domain" {
   default     = ""
 }
 
+variable "openshift_cluster_cidr" {
+  type        = "string"
+  default     = "10.128.0.0/14"
+  description = "This variable overrides the SDN cluster network CIDR block. This is the network from which pod IPs are assigned. Specify a private block that does not conflict with existing network blocks in your infrastructure to which pods, nodes, or the master might require access"
+}
+
 variable "rh_subscription_pool_id" {
   description = "Red Hat subscription pool id for OpenShift Container Platform"
   default     = ""

--- a/modules/openshift/variables.tf
+++ b/modules/openshift/variables.tf
@@ -1,29 +1,30 @@
 variable "platform_name" {}
 
 variable "identity_providers" {
-    type        = "list"
-    description = "The identity providers to enable (AllowAllIdentityProvider, GoogleIdentityProvider, HTPasswdPasswordIdentityProvider)"
-    default     = [
-        "AllowAllIdentityProvider"
-    ]
+  type        = "list"
+  description = "The identity providers to enable (AllowAllIdentityProvider, GoogleIdentityProvider, HTPasswdPasswordIdentityProvider)"
+
+  default = [
+    "AllowAllIdentityProvider",
+  ]
 }
 
 variable "google_client_id" {
-    type        = "string"
-    description = "The Google client id used by the GoogleIdentityProvider"
-    default     = ""
+  type        = "string"
+  description = "The Google client id used by the GoogleIdentityProvider"
+  default     = ""
 }
 
 variable "google_client_secret" {
-    type        = "string"
-    description = "The client secret used by the GoogleIdentityProvider"
-    default     = ""
+  type        = "string"
+  description = "The client secret used by the GoogleIdentityProvider"
+  default     = ""
 }
 
 variable "google_client_domain" {
-    type        = "string"
-    description = "The domain used by the GoogleIdentityProvider"
-    default     = ""
+  type        = "string"
+  description = "The domain used by the GoogleIdentityProvider"
+  default     = ""
 }
 
 variable "rh_subscription_pool_id" {

--- a/modules/openshift/variables.tf
+++ b/modules/openshift/variables.tf
@@ -33,6 +33,12 @@ variable "openshift_cluster_cidr" {
   description = "This variable overrides the SDN cluster network CIDR block. This is the network from which pod IPs are assigned. Specify a private block that does not conflict with existing network blocks in your infrastructure to which pods, nodes, or the master might require access"
 }
 
+variable "openshift_services_cidr" {
+  type        = "string"
+  default     = "172.30.0.0/16"
+  description = "This variable overrides the OpenShift CIDR block used for services. This is the network from which service IPs are assigned. Specify a private block that does not conflict with existing network blocks in your infrastructure to which pods, nodes, or the master might require access"
+}
+
 variable "rh_subscription_pool_id" {
   description = "Red Hat subscription pool id for OpenShift Container Platform"
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -113,6 +113,12 @@ variable "openshift_cluster_cidr" {
   description = "This variable overrides the SDN cluster network CIDR block. This is the network from which pod IPs are assigned. Specify a private block that does not conflict with existing network blocks in your infrastructure to which pods, nodes, or the master might require access"
 }
 
+variable "openshift_services_cidr" {
+  type        = "string"
+  default     = "172.30.0.0/16"
+  description = "This variable overrides the OpenShift CIDR block used for services. This is the network from which service IPs are assigned. Specify a private block that does not conflict with existing network blocks in your infrastructure to which pods, nodes, or the master might require access"
+}
+
 variable "platform_cidr" {
   default = "10.0.0.0/16"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,13 @@ variable "google_client_domain" {
   description = "The domain used by the GoogleIdentityProvider"
   default     = ""
 }
+
+variable "openshift_cluster_cidr" {
+  type        = "string"
+  default     = "10.128.0.0/14"
+  description = "This variable overrides the SDN cluster network CIDR block. This is the network from which pod IPs are assigned. Specify a private block that does not conflict with existing network blocks in your infrastructure to which pods, nodes, or the master might require access"
+}
+
+variable "platform_cidr" {
+  default = "10.0.0.0/16"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,6 @@ variable "use_community" {
   default     = false
 }
 
-
 variable "use_specific_base_image" {
   description = "Indicates whether the module should use a specific base image or find the latest."
   default     = false
@@ -82,27 +81,28 @@ variable "platform_domain_administrator_email" {
 }
 
 variable "identity_providers" {
-    type        = "list"
-    description = "The identity providers to enable (AllowAllIdentityProvider, GoogleIdentityProvider, HTPasswdPasswordIdentityProvider)"
-    default     = [
-        "AllowAllIdentityProvider"
-    ]
+  type        = "list"
+  description = "The identity providers to enable (AllowAllIdentityProvider, GoogleIdentityProvider, HTPasswdPasswordIdentityProvider)"
+
+  default = [
+    "AllowAllIdentityProvider",
+  ]
 }
 
 variable "google_client_id" {
-    type        = "string"
-    description = "The Google client id used by the GoogleIdentityProvider"
-    default     = ""
+  type        = "string"
+  description = "The Google client id used by the GoogleIdentityProvider"
+  default     = ""
 }
 
 variable "google_client_secret" {
-    type        = "string"
-    description = "The client secret used by the GoogleIdentityProvider"
-    default     = ""
+  type        = "string"
+  description = "The client secret used by the GoogleIdentityProvider"
+  default     = ""
 }
 
 variable "google_client_domain" {
-    type        = "string"
-    description = "The domain used by the GoogleIdentityProvider"
-    default     = ""
+  type        = "string"
+  description = "The domain used by the GoogleIdentityProvider"
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -116,3 +116,13 @@ variable "openshift_cluster_cidr" {
 variable "platform_cidr" {
   default = "10.0.0.0/16"
 }
+
+variable "priv_subnet_count" {
+  default     = "100"
+  description = "Sets a desired number of subnets Terraform will attempt to use.  This value is compared to the total number of subnets available in the selected region and uses the min of the two values"
+}
+
+variable "pub_subnet_count" {
+  default     = "100"
+  description = "Sets a desired number of subnets Terraform will attempt to use.  This value is compared to the total number of subnets available in the selected region and uses the min of the two values"
+}


### PR DESCRIPTION
Add the ability for the operator to define the CIDR blocks for the VPC and the OpenShift network.  

Add the ability for the operator to define a desired number of subnets to utilize.  This value will be `min'd` with the total number of subnets in the AZ.