### PR TITLE
Use the dev api for LetsEncrypt if developing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,8 @@ module "domain" {
   platform_domain                     = "${var.platform_domain}"
   platform_domain_administrator_email = "${var.platform_domain_administrator_email}"
   public_lb_arn                       = "${module.infra.public_lb_arn}"
+
+  use_staging_acme = "${var.use_staging_acme}"
 }
 
 module "openshift" {

--- a/modules/domain/certificates.tf
+++ b/modules/domain/certificates.tf
@@ -1,5 +1,5 @@
 provider "acme" {
-  server_url = "https://acme-v02.api.letsencrypt.org/directory"
+  server_url = "${var.use_staging_acme == "true" ? "https://acme-staging-v02.api.letsencrypt.org/directory" : "https://acme-v02.api.letsencrypt.org/directory"}"
 }
 
 resource "tls_private_key" "platform_domain_administrator" {

--- a/modules/domain/variables.tf
+++ b/modules/domain/variables.tf
@@ -5,3 +5,5 @@ variable "platform_domain" {}
 variable "platform_domain_administrator_email" {}
 
 variable "public_lb_arn" {}
+
+variable "use_staging_acme" {}

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,8 @@ variable "pub_subnet_count" {
   default     = "100"
   description = "Sets a desired number of subnets Terraform will attempt to use.  This value is compared to the total number of subnets available in the selected region and uses the min of the two values"
 }
+
+variable "use_staging_acme" {
+  default     = false
+  description = "Determine if the LetsEncrypt module should use the development API or the production.  Helpful for development and debugging purposes.  Avoids LetsEncrypt's rate limits"
+}


### PR DESCRIPTION
Adds a variables that defines if the module should access LetsEncrypt's production or staging APIs. In a development situation, this is important because you will run into rate limits with LetsEncrypt

Closes #10 